### PR TITLE
Set country on custom CR chart template

### DIFF
--- a/l10n_cr_custom_18_v2/models/template_cr.py
+++ b/l10n_cr_custom_18_v2/models/template_cr.py
@@ -12,8 +12,9 @@ class L10nCRTemplate(models.AbstractModel):
             'name': _('Costa Rica - Custom'),
             'visible': True,
             'code_digits': '7',
+            'country_id': 'base.cr',
             'property_account_receivable_id': 'cr_coa_1040101',
-            'property_account_payable_id': 'cr_coa_2010101', 
+            'property_account_payable_id': 'cr_coa_2010101',
         }
 
     @template('cr_custom', 'res.company')


### PR DESCRIPTION
## Summary
- add Costa Rica country to the custom chart template metadata so it is auto-selected for companies in that country

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d5a64fe06083269d18916bbc8f9dea