### PR TITLE
Add sales and purchases summary report

### DIFF
--- a/l10n_cr_custom_18_v2/__init__.py
+++ b/l10n_cr_custom_18_v2/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import reports

--- a/l10n_cr_custom_18_v2/__manifest__.py
+++ b/l10n_cr_custom_18_v2/__manifest__.py
@@ -14,7 +14,11 @@
         "data/template/account.group-cr.csv",
         "data/template/account.tax.group-cr.csv",
         "data/template/account.tax-cr.csv",
-        "data/template/account.fiscal.position-cr.csv"
+        "data/template/account.fiscal.position-cr.csv",
+        "report/report_sales_purchase.xml"
+    ],
+    "qweb": [
+        "report/report_sales_purchase_templates.xml"
     ],
     "demo": [],
     "installable": True,

--- a/l10n_cr_custom_18_v2/report/report_sales_purchase.xml
+++ b/l10n_cr_custom_18_v2/report/report_sales_purchase.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <report
+        id="action_report_sales_purchase"
+        model="account.move"
+        string="Reporte de Compras y Ventas"
+        report_type="qweb-pdf"
+        name="l10n_cr_custom_18_v2.report_sales_purchase"
+        file="l10n_cr_custom_18_v2.report_sales_purchase"
+        print_report_name="'Reporte_Compras_Ventas_' + (object.name or '')"
+        binding_model_id="account.model_account_move"
+        binding_type="report"
+    />
+</odoo>

--- a/l10n_cr_custom_18_v2/report/report_sales_purchase_templates.xml
+++ b/l10n_cr_custom_18_v2/report/report_sales_purchase_templates.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="report_sales_purchase_document">
+        <t t-call="web.html_container">
+            <t t-call="web.external_layout">
+                <div class="page">
+                    <h2>Reporte de Compras y Ventas</h2>
+                    <p>
+                        <span t-esc="company.name"/>
+                    </p>
+                    <t t-if="sale_moves">
+                        <h3>Ventas</h3>
+                        <table class="table table-sm o_main_table">
+                            <thead>
+                                <tr>
+                                    <th>Documento</th>
+                                    <th>Cliente</th>
+                                    <th>Fecha</th>
+                                    <th class="text-right">Base</th>
+                                    <th class="text-right">Impuestos</th>
+                                    <th class="text-right">Total</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr t-foreach="sale_moves" t-as="move">
+                                    <td>
+                                        <span t-esc="move.name or move.ref"/>
+                                    </td>
+                                    <td>
+                                        <span t-esc="move.partner_id.display_name"/>
+                                    </td>
+                                    <td>
+                                        <span t-esc="format_date(move.invoice_date or move.date)"/>
+                                    </td>
+                                    <td class="text-right">
+                                        <span t-esc="formatLang(move.amount_untaxed, currency_obj=move.currency_id)"/>
+                                    </td>
+                                    <td class="text-right">
+                                        <span t-esc="formatLang(move.amount_tax, currency_obj=move.currency_id)"/>
+                                    </td>
+                                    <td class="text-right">
+                                        <span t-esc="formatLang(move.amount_total, currency_obj=move.currency_id)"/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                            <tfoot>
+                                <tr>
+                                    <th colspan="3" class="text-right">Totales</th>
+                                    <th class="text-right">
+                                        <span t-esc="formatLang(sale_totals['base'], currency_obj=company_currency)"/>
+                                    </th>
+                                    <th class="text-right">
+                                        <span t-esc="formatLang(sale_totals['tax'], currency_obj=company_currency)"/>
+                                    </th>
+                                    <th class="text-right">
+                                        <span t-esc="formatLang(sale_totals['total'], currency_obj=company_currency)"/>
+                                    </th>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </t>
+                    <t t-if="purchase_moves">
+                        <h3>Compras</h3>
+                        <table class="table table-sm o_main_table">
+                            <thead>
+                                <tr>
+                                    <th>Documento</th>
+                                    <th>Proveedor</th>
+                                    <th>Fecha</th>
+                                    <th class="text-right">Base</th>
+                                    <th class="text-right">Impuestos</th>
+                                    <th class="text-right">Total</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr t-foreach="purchase_moves" t-as="move">
+                                    <td>
+                                        <span t-esc="move.name or move.ref"/>
+                                    </td>
+                                    <td>
+                                        <span t-esc="move.partner_id.display_name"/>
+                                    </td>
+                                    <td>
+                                        <span t-esc="format_date(move.invoice_date or move.date)"/>
+                                    </td>
+                                    <td class="text-right">
+                                        <span t-esc="formatLang(move.amount_untaxed, currency_obj=move.currency_id)"/>
+                                    </td>
+                                    <td class="text-right">
+                                        <span t-esc="formatLang(move.amount_tax, currency_obj=move.currency_id)"/>
+                                    </td>
+                                    <td class="text-right">
+                                        <span t-esc="formatLang(move.amount_total, currency_obj=move.currency_id)"/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                            <tfoot>
+                                <tr>
+                                    <th colspan="3" class="text-right">Totales</th>
+                                    <th class="text-right">
+                                        <span t-esc="formatLang(purchase_totals['base'], currency_obj=company_currency)"/>
+                                    </th>
+                                    <th class="text-right">
+                                        <span t-esc="formatLang(purchase_totals['tax'], currency_obj=company_currency)"/>
+                                    </th>
+                                    <th class="text-right">
+                                        <span t-esc="formatLang(purchase_totals['total'], currency_obj=company_currency)"/>
+                                    </th>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </t>
+                    <t t-if="not sale_moves and not purchase_moves">
+                        <p>No se encontraron movimientos de ventas o compras para los registros seleccionados.</p>
+                    </t>
+                    <div class="mt16">
+                        <strong>Total general</strong>
+                        <table class="table table-sm o_main_table">
+                            <tbody>
+                                <tr>
+                                    <th>Base</th>
+                                    <td class="text-right">
+                                        <span t-esc="formatLang(grand_totals['base'], currency_obj=company_currency)"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>Impuestos</th>
+                                    <td class="text-right">
+                                        <span t-esc="formatLang(grand_totals['tax'], currency_obj=company_currency)"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>Total</th>
+                                    <td class="text-right">
+                                        <span t-esc="formatLang(grand_totals['total'], currency_obj=company_currency)"/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/l10n_cr_custom_18_v2/reports/__init__.py
+++ b/l10n_cr_custom_18_v2/reports/__init__.py
@@ -1,0 +1,1 @@
+from . import report_sales_purchase

--- a/l10n_cr_custom_18_v2/reports/report_sales_purchase.py
+++ b/l10n_cr_custom_18_v2/reports/report_sales_purchase.py
@@ -1,0 +1,45 @@
+from odoo import models
+
+
+class ReportSalesPurchase(models.AbstractModel):
+    _name = 'report.l10n_cr_custom_18_v2.report_sales_purchase'
+    _description = 'Reporte de Compras y Ventas'
+
+    def _get_report_values(self, docids, data=None):
+        moves = self.env['account.move'].browse(docids)
+        relevant_moves = moves.filtered(
+            lambda m: m.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')
+        )
+
+        def _ordered(records):
+            return records.sorted(key=lambda m: (m.invoice_date or m.date or False, m.name or m.ref or m.id))
+
+        sale_moves = _ordered(
+            relevant_moves.filtered(lambda m: m.move_type in ('out_invoice', 'out_refund'))
+        )
+        purchase_moves = _ordered(
+            relevant_moves.filtered(lambda m: m.move_type in ('in_invoice', 'in_refund'))
+        )
+
+        def _totals(recordset):
+            return {
+                'base': sum(recordset.mapped('amount_untaxed')),
+                'tax': sum(recordset.mapped('amount_tax')),
+                'total': sum(recordset.mapped('amount_total')),
+            }
+
+        company = self.env.company
+        company_currency = company.currency_id
+
+        return {
+            'doc_ids': relevant_moves.ids,
+            'doc_model': 'account.move',
+            'docs': relevant_moves,
+            'sale_moves': sale_moves,
+            'purchase_moves': purchase_moves,
+            'sale_totals': _totals(sale_moves),
+            'purchase_totals': _totals(purchase_moves),
+            'grand_totals': _totals(relevant_moves),
+            'company': company,
+            'company_currency': company_currency,
+        }


### PR DESCRIPTION
## Summary
- add a QWeb report for account moves that lists sales and purchase documents with partner name, untaxed amount, tax and total
- register the report action in the Costa Rica localization module so it can be printed from invoices

## Testing
- python -m compileall l10n_cr_custom_18_v2

------
https://chatgpt.com/codex/tasks/task_e_68d59de5b77483269e04c32fffa4deb5