### PR TITLE
Add tax report wizard accessible from accounting reports menu

### DIFF
--- a/l10n_cr_custom_18_v2/__init__.py
+++ b/l10n_cr_custom_18_v2/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import reports
+from . import wizard

--- a/l10n_cr_custom_18_v2/__manifest__.py
+++ b/l10n_cr_custom_18_v2/__manifest__.py
@@ -15,7 +15,8 @@
         "data/template/account.tax.group-cr.csv",
         "data/template/account.tax-cr.csv",
         "data/template/account.fiscal.position-cr.csv",
-        "report/report_sales_purchase.xml"
+        "report/report_sales_purchase.xml",
+        "wizard/tax_report_wizard_views.xml",
     ],
     "qweb": [
         "report/report_sales_purchase_templates.xml"

--- a/l10n_cr_custom_18_v2/report/report_sales_purchase.xml
+++ b/l10n_cr_custom_18_v2/report/report_sales_purchase.xml
@@ -11,4 +11,16 @@
         binding_model_id="account.model_account_move"
         binding_type="report"
     />
+    <report
+        id="action_report_sales_purchase_detail"
+        model="account.move"
+        string="Reporte de Compras y Ventas (Detallado)"
+        report_type="qweb-pdf"
+        name="l10n_cr_custom_18_v2.report_sales_purchase"
+        file="l10n_cr_custom_18_v2.report_sales_purchase"
+        print_report_name="'Reporte_Compras_Ventas_Detallado_' + (object.name or '')"
+        binding_model_id="account.model_account_move"
+        binding_type="report"
+        context="{'report_detail': True}"
+    />
 </odoo>

--- a/l10n_cr_custom_18_v2/report/report_sales_purchase_templates.xml
+++ b/l10n_cr_custom_18_v2/report/report_sales_purchase_templates.xml
@@ -8,44 +8,36 @@
                     <p>
                         <span t-esc="company.name"/>
                     </p>
-                    <t t-if="sale_moves">
+                    <t t-if="sale_summary">
                         <h3>Ventas</h3>
                         <table class="table table-sm o_main_table">
                             <thead>
                                 <tr>
-                                    <th>Documento</th>
-                                    <th>Cliente</th>
-                                    <th>Fecha</th>
+                                    <th>Impuesto</th>
                                     <th class="text-right">Base</th>
-                                    <th class="text-right">Impuestos</th>
+                                    <th class="text-right">Impuesto</th>
                                     <th class="text-right">Total</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr t-foreach="sale_moves" t-as="move">
+                                <tr t-foreach="sale_summary" t-as="line">
                                     <td>
-                                        <span t-esc="move.name or move.ref"/>
-                                    </td>
-                                    <td>
-                                        <span t-esc="move.partner_id.display_name"/>
-                                    </td>
-                                    <td>
-                                        <span t-esc="format_date(move.invoice_date or move.date)"/>
+                                        <span t-esc="line['tax_name']"/>
                                     </td>
                                     <td class="text-right">
-                                        <span t-esc="formatLang(move.amount_untaxed, currency_obj=move.currency_id)"/>
+                                        <span t-esc="formatLang(line['base'], currency_obj=company_currency)"/>
                                     </td>
                                     <td class="text-right">
-                                        <span t-esc="formatLang(move.amount_tax, currency_obj=move.currency_id)"/>
+                                        <span t-esc="formatLang(line['tax'], currency_obj=company_currency)"/>
                                     </td>
                                     <td class="text-right">
-                                        <span t-esc="formatLang(move.amount_total, currency_obj=move.currency_id)"/>
+                                        <span t-esc="formatLang(line['total'], currency_obj=company_currency)"/>
                                     </td>
                                 </tr>
                             </tbody>
                             <tfoot>
                                 <tr>
-                                    <th colspan="3" class="text-right">Totales</th>
+                                    <th class="text-right">Totales</th>
                                     <th class="text-right">
                                         <span t-esc="formatLang(sale_totals['base'], currency_obj=company_currency)"/>
                                     </th>
@@ -59,44 +51,36 @@
                             </tfoot>
                         </table>
                     </t>
-                    <t t-if="purchase_moves">
+                    <t t-if="purchase_summary">
                         <h3>Compras</h3>
                         <table class="table table-sm o_main_table">
                             <thead>
                                 <tr>
-                                    <th>Documento</th>
-                                    <th>Proveedor</th>
-                                    <th>Fecha</th>
+                                    <th>Impuesto</th>
                                     <th class="text-right">Base</th>
-                                    <th class="text-right">Impuestos</th>
+                                    <th class="text-right">Impuesto</th>
                                     <th class="text-right">Total</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr t-foreach="purchase_moves" t-as="move">
+                                <tr t-foreach="purchase_summary" t-as="line">
                                     <td>
-                                        <span t-esc="move.name or move.ref"/>
-                                    </td>
-                                    <td>
-                                        <span t-esc="move.partner_id.display_name"/>
-                                    </td>
-                                    <td>
-                                        <span t-esc="format_date(move.invoice_date or move.date)"/>
+                                        <span t-esc="line['tax_name']"/>
                                     </td>
                                     <td class="text-right">
-                                        <span t-esc="formatLang(move.amount_untaxed, currency_obj=move.currency_id)"/>
+                                        <span t-esc="formatLang(line['base'], currency_obj=company_currency)"/>
                                     </td>
                                     <td class="text-right">
-                                        <span t-esc="formatLang(move.amount_tax, currency_obj=move.currency_id)"/>
+                                        <span t-esc="formatLang(line['tax'], currency_obj=company_currency)"/>
                                     </td>
                                     <td class="text-right">
-                                        <span t-esc="formatLang(move.amount_total, currency_obj=move.currency_id)"/>
+                                        <span t-esc="formatLang(line['total'], currency_obj=company_currency)"/>
                                     </td>
                                 </tr>
                             </tbody>
                             <tfoot>
                                 <tr>
-                                    <th colspan="3" class="text-right">Totales</th>
+                                    <th class="text-right">Totales</th>
                                     <th class="text-right">
                                         <span t-esc="formatLang(purchase_totals['base'], currency_obj=company_currency)"/>
                                     </th>
@@ -110,8 +94,87 @@
                             </tfoot>
                         </table>
                     </t>
-                    <t t-if="not sale_moves and not purchase_moves">
-                        <p>No se encontraron movimientos de ventas o compras para los registros seleccionados.</p>
+                    <t t-if="not sale_summary and not purchase_summary">
+                        <p>No se encontraron impuestos generados para los registros seleccionados.</p>
+                    </t>
+                    <t t-if="show_details and (sale_details or purchase_details)">
+                        <div class="mt16">
+                            <h3>Detalle por documento</h3>
+                        </div>
+                        <t t-if="sale_details">
+                            <h4>Ventas</h4>
+                            <table class="table table-sm o_main_table">
+                                <thead>
+                                    <tr>
+                                        <th>Documento</th>
+                                        <th>Fecha</th>
+                                        <th>Impuesto</th>
+                                        <th class="text-right">Base</th>
+                                        <th class="text-right">Impuesto</th>
+                                        <th class="text-right">Total</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr t-foreach="sale_details" t-as="detail">
+                                        <td>
+                                            <span t-esc="detail['document']"/>
+                                        </td>
+                                        <td>
+                                            <span t-esc="format_date(detail['date'])"/>
+                                        </td>
+                                        <td>
+                                            <span t-esc="detail['tax_name']"/>
+                                        </td>
+                                        <td class="text-right">
+                                            <span t-esc="formatLang(detail['base'], currency_obj=company_currency)"/>
+                                        </td>
+                                        <td class="text-right">
+                                            <span t-esc="formatLang(detail['tax'], currency_obj=company_currency)"/>
+                                        </td>
+                                        <td class="text-right">
+                                            <span t-esc="formatLang(detail['total'], currency_obj=company_currency)"/>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </t>
+                        <t t-if="purchase_details">
+                            <h4>Compras</h4>
+                            <table class="table table-sm o_main_table">
+                                <thead>
+                                    <tr>
+                                        <th>Documento</th>
+                                        <th>Fecha</th>
+                                        <th>Impuesto</th>
+                                        <th class="text-right">Base</th>
+                                        <th class="text-right">Impuesto</th>
+                                        <th class="text-right">Total</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr t-foreach="purchase_details" t-as="detail">
+                                        <td>
+                                            <span t-esc="detail['document']"/>
+                                        </td>
+                                        <td>
+                                            <span t-esc="format_date(detail['date'])"/>
+                                        </td>
+                                        <td>
+                                            <span t-esc="detail['tax_name']"/>
+                                        </td>
+                                        <td class="text-right">
+                                            <span t-esc="formatLang(detail['base'], currency_obj=company_currency)"/>
+                                        </td>
+                                        <td class="text-right">
+                                            <span t-esc="formatLang(detail['tax'], currency_obj=company_currency)"/>
+                                        </td>
+                                        <td class="text-right">
+                                            <span t-esc="formatLang(detail['total'], currency_obj=company_currency)"/>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </t>
                     </t>
                     <div class="mt16">
                         <strong>Total general</strong>

--- a/l10n_cr_custom_18_v2/reports/report_sales_purchase.py
+++ b/l10n_cr_custom_18_v2/reports/report_sales_purchase.py
@@ -1,4 +1,6 @@
-from odoo import models
+from collections import defaultdict
+
+from odoo import fields, models
 
 
 class ReportSalesPurchase(models.AbstractModel):
@@ -21,15 +23,70 @@ class ReportSalesPurchase(models.AbstractModel):
             relevant_moves.filtered(lambda m: m.move_type in ('in_invoice', 'in_refund'))
         )
 
-        def _totals(recordset):
-            return {
-                'base': sum(recordset.mapped('amount_untaxed')),
-                'tax': sum(recordset.mapped('amount_tax')),
-                'total': sum(recordset.mapped('amount_total')),
-            }
-
         company = self.env.company
         company_currency = company.currency_id
+
+        today = fields.Date.context_today(self)
+
+        def _tax_report_values(moveset):
+            summary = defaultdict(lambda: {
+                'tax_id': False,
+                'tax_name': '',
+                'base': 0.0,
+                'tax': 0.0,
+                'total': 0.0,
+            })
+            details = []
+
+            for move in moveset:
+                tax_lines = move.line_ids.filtered('tax_line_id')
+                for line in tax_lines:
+                    tax = line.tax_line_id
+                    base_amount = company_currency.round(line.tax_base_amount or 0.0)
+                    tax_amount = company_currency.round(line.balance or 0.0)
+                    total_amount = base_amount + tax_amount
+
+                    entry = summary[tax.id]
+                    entry['tax_id'] = tax.id
+                    entry['tax_name'] = tax.display_name or tax.name
+                    entry['base'] += base_amount
+                    entry['tax'] += tax_amount
+                    entry['total'] += total_amount
+
+                    details.append({
+                        'document': move.name or move.ref or '',
+                        'date': fields.Date.to_date(move.invoice_date or move.date),
+                        'tax_name': entry['tax_name'],
+                        'base': base_amount,
+                        'tax': tax_amount,
+                        'total': total_amount,
+                    })
+
+            summary_list = sorted(summary.values(), key=lambda item: item['tax_name'] or '')
+            details.sort(key=lambda item: (item['date'] or today, item['document']))
+
+            totals = {
+                'base': sum(item['base'] for item in summary_list),
+                'tax': sum(item['tax'] for item in summary_list),
+            }
+            totals['total'] = totals['base'] + totals['tax']
+
+            return {
+                'summary': summary_list,
+                'details': details,
+                'totals': totals,
+            }
+
+        sale_data = _tax_report_values(sale_moves)
+        purchase_data = _tax_report_values(purchase_moves)
+
+        grand_totals = {
+            'base': sale_data['totals']['base'] + purchase_data['totals']['base'],
+            'tax': sale_data['totals']['tax'] + purchase_data['totals']['tax'],
+        }
+        grand_totals['total'] = grand_totals['base'] + grand_totals['tax']
+
+        show_details = bool(self.env.context.get('report_detail') or (data or {}).get('report_detail'))
 
         return {
             'doc_ids': relevant_moves.ids,
@@ -37,9 +94,14 @@ class ReportSalesPurchase(models.AbstractModel):
             'docs': relevant_moves,
             'sale_moves': sale_moves,
             'purchase_moves': purchase_moves,
-            'sale_totals': _totals(sale_moves),
-            'purchase_totals': _totals(purchase_moves),
-            'grand_totals': _totals(relevant_moves),
+            'sale_summary': sale_data['summary'],
+            'purchase_summary': purchase_data['summary'],
+            'sale_totals': sale_data['totals'],
+            'purchase_totals': purchase_data['totals'],
+            'sale_details': sale_data['details'],
+            'purchase_details': purchase_data['details'],
+            'grand_totals': grand_totals,
+            'show_details': show_details,
             'company': company,
             'company_currency': company_currency,
         }

--- a/l10n_cr_custom_18_v2/wizard/__init__.py
+++ b/l10n_cr_custom_18_v2/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import tax_report_wizard

--- a/l10n_cr_custom_18_v2/wizard/tax_report_wizard.py
+++ b/l10n_cr_custom_18_v2/wizard/tax_report_wizard.py
@@ -1,0 +1,66 @@
+from odoo import fields, models
+
+
+class TaxReportWizard(models.TransientModel):
+    _name = 'l10n.cr.tax.report.wizard'
+    _description = 'Asistente de Reporte de Compras y Ventas'
+
+    date_from = fields.Date(string='Fecha desde')
+    date_to = fields.Date(string='Fecha hasta')
+    target_move = fields.Selection(
+        selection=[
+            ('posted', 'Publicadas'),
+            ('all', 'Todas (Borrador y Publicadas)'),
+        ],
+        string='Movimientos',
+        default='posted',
+        required=True,
+    )
+
+    def _prepare_domain(self):
+        self.ensure_one()
+        domain = [
+            ('company_id', '=', self.env.company.id),
+            (
+                'move_type',
+                'in',
+                ('out_invoice', 'out_refund', 'in_invoice', 'in_refund'),
+            ),
+        ]
+        if self.target_move == 'posted':
+            domain.append(('state', '=', 'posted'))
+        if self.date_from:
+            domain.extend([
+                '|',
+                ('invoice_date', '>=', self.date_from),
+                ('date', '>=', self.date_from),
+            ])
+        if self.date_to:
+            domain.extend([
+                '|',
+                ('invoice_date', '<=', self.date_to),
+                ('date', '<=', self.date_to),
+            ])
+        return domain
+
+    def _get_moves(self):
+        self.ensure_one()
+        domain = self._prepare_domain()
+        return self.env['account.move'].search(domain, order='invoice_date, date, name')
+
+    def _run_report(self, detailed=False):
+        self.ensure_one()
+        moves = self._get_moves()
+        action_xmlid = 'l10n_cr_custom_18_v2.action_report_sales_purchase'
+        if detailed:
+            action_xmlid = 'l10n_cr_custom_18_v2.action_report_sales_purchase_detail'
+        action = self.env.ref(action_xmlid)
+        context = dict(self.env.context)
+        context.update({'report_detail': detailed})
+        return action.with_context(context).report_action(moves)
+
+    def action_print_summary(self):
+        return self._run_report(detailed=False)
+
+    def action_print_detail(self):
+        return self._run_report(detailed=True)

--- a/l10n_cr_custom_18_v2/wizard/tax_report_wizard_views.xml
+++ b/l10n_cr_custom_18_v2/wizard/tax_report_wizard_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_tax_report_wizard_form" model="ir.ui.view">
+        <field name="name">l10n.cr.tax.report.wizard.form</field>
+        <field name="model">l10n.cr.tax.report.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Reporte de Compras y Ventas">
+                <group>
+                    <group>
+                        <field name="date_from"/>
+                        <field name="date_to"/>
+                        <field name="target_move" widget="radio"/>
+                    </group>
+                </group>
+                <footer>
+                    <button name="action_print_detail" type="object" class="btn-primary" string="Imprimir detallado"/>
+                    <button name="action_print_summary" type="object" class="btn-secondary" string="Imprimir resumen"/>
+                    <button special="cancel" class="btn-link" string="Cancelar"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_tax_report_wizard" model="ir.actions.act_window">
+        <field name="name">Reporte de Compras y Ventas</field>
+        <field name="res_model">l10n.cr.tax.report.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_tax_report_wizard_form"/>
+        <field name="target">new</field>
+    </record>
+
+    <menuitem id="menu_tax_report_root" name="Reporte de Compras y Ventas" parent="account.menu_finance_reports" action="action_tax_report_wizard" sequence="75"/>
+</odoo>


### PR DESCRIPTION
## Summary
- add a wizard to launch the purchases and sales tax reports with optional date range and move state filters
- expose the wizard from the Accounting → Reports menu so users can print either the summary or detailed tax report directly
- wire the wizard buttons to the existing summary and detailed report actions, preserving the detailed layout when requested

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5af00d8dc832684dc6384d7bee6e9