### PR TITLE
Restore data wrapper for sales/purchase reports

### DIFF
--- a/l10n_cr_custom_18_v2/report/report_sales_purchase.xml
+++ b/l10n_cr_custom_18_v2/report/report_sales_purchase.xml
@@ -27,28 +27,4 @@
         />
     </data>
 
-    <report
-        id="action_report_sales_purchase"
-        model="account.move"
-        string="Reporte de Compras y Ventas"
-        report_type="qweb-pdf"
-        name="l10n_cr_custom_18_v2.report_sales_purchase"
-        file="l10n_cr_custom_18_v2.report_sales_purchase"
-        print_report_name="'Reporte_Compras_Ventas_' + (object.name or '')"
-        binding_model_id="account.model_account_move"
-        binding_type="report"
-    />
-    <report
-        id="action_report_sales_purchase_detail"
-        model="account.move"
-        string="Reporte de Compras y Ventas (Detallado)"
-        report_type="qweb-pdf"
-        name="l10n_cr_custom_18_v2.report_sales_purchase"
-        file="l10n_cr_custom_18_v2.report_sales_purchase"
-        print_report_name="'Reporte_Compras_Ventas_Detallado_' + (object.name or '')"
-        binding_model_id="account.model_account_move"
-        binding_type="report"
-        context="{'report_detail': True}"
-    />
-
 </odoo>


### PR DESCRIPTION
## Summary
- wrap the sales/purchase report actions inside a single <data> block under <odoo>

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5b9b94388832684a28073bc2563c9