### PR TITLE
Fix report XML structure for Odoo install

### DIFF
--- a/l10n_cr_custom_18_v2/report/report_sales_purchase.xml
+++ b/l10n_cr_custom_18_v2/report/report_sales_purchase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
- <data>
-      <report
+    <data>
+        <report
             id="action_report_sales_purchase"
             model="account.move"
             string="Reporte de Compras y Ventas"
@@ -25,27 +25,4 @@
             context="{'report_detail': True}"
         />
     </data>
-    <report
-        id="action_report_sales_purchase"
-        model="account.move"
-        string="Reporte de Compras y Ventas"
-        report_type="qweb-pdf"
-        name="l10n_cr_custom_18_v2.report_sales_purchase"
-        file="l10n_cr_custom_18_v2.report_sales_purchase"
-        print_report_name="'Reporte_Compras_Ventas_' + (object.name or '')"
-        binding_model_id="account.model_account_move"
-        binding_type="report"
-    />
-    <report
-        id="action_report_sales_purchase_detail"
-        model="account.move"
-        string="Reporte de Compras y Ventas (Detallado)"
-        report_type="qweb-pdf"
-        name="l10n_cr_custom_18_v2.report_sales_purchase"
-        file="l10n_cr_custom_18_v2.report_sales_purchase"
-        print_report_name="'Reporte_Compras_Ventas_Detallado_' + (object.name or '')"
-        binding_model_id="account.model_account_move"
-        binding_type="report"
-        context="{'report_detail': True}"
-    />
 </odoo>

--- a/l10n_cr_custom_18_v2/wizard/tax_report_wizard_views.xml
+++ b/l10n_cr_custom_18_v2/wizard/tax_report_wizard_views.xml
@@ -29,5 +29,11 @@
         <field name="target">new</field>
     </record>
 
-    <menuitem id="menu_tax_report_root" name="Reporte de Compras y Ventas" parent="account.menu_finance_reports" action="action_tax_report_wizard" sequence="75"/>
+    <menuitem
+        id="menu_tax_report_root"
+        name="Reporte de Compras y Ventas"
+        parent="account.menu_finance_reports"
+        action="action_tax_report_wizard"
+        sequence="75"
+    />
 </odoo>


### PR DESCRIPTION
## Summary
- remove duplicated top-level report records in report_sales_purchase.xml that broke XML validation
- clean the wizard menuitem definition formatting to avoid malformed attributes

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5be08c6e883268aee7c0bf078d908