### PR TITLE
Fix XML schema error when installing module

### DIFF
--- a/l10n_cr_custom_18_v2/report/report_sales_purchase.xml
+++ b/l10n_cr_custom_18_v2/report/report_sales_purchase.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    
+    <data>
         <report
             id="action_report_sales_purchase"
             model="account.move"
@@ -24,5 +24,5 @@
             binding_type="report"
             context="{'report_detail': True}"
         />
-    
+    </data>
 </odoo>


### PR DESCRIPTION
## Summary
- wrap the report definitions in report/report_sales_purchase.xml inside a <data> tag so the XML conforms to Odoo's schema

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5c13a327c8326a48d100f422cd2ed