### PR TITLE
Fix chart template data structure

### DIFF
--- a/l10n_cr_custom_18_v2/models/template_cr.py
+++ b/l10n_cr_custom_18_v2/models/template_cr.py
@@ -9,14 +9,16 @@ class L10nCRTemplate(models.AbstractModel):
     def _get_cr_custom_template_data(self):
         # Minimal template data; code_digits set to 7 based on provided CoA
         return {
-            'name': _('Costa Rica - Custom'),
-            'visible': True,
-            'code_digits': '7',
-            'country_id': 'base.cr',
-            'property_account_receivable_id': 'cr_coa_1040101',
-            'property_account_payable_id': 'cr_coa_2010101',
-            'default_sale_journal_id': 'cr_custom_sale_journal',
-            'default_purchase_journal_id': 'cr_custom_purchase_journal',
+            'template_data': {
+                'name': _('Costa Rica - Custom'),
+                'visible': True,
+                'code_digits': '7',
+                'country_id': 'base.cr',
+                'property_account_receivable_id': 'cr_coa_1040101',
+                'property_account_payable_id': 'cr_coa_2010101',
+                'default_sale_journal_id': 'cr_custom_sale_journal',
+                'default_purchase_journal_id': 'cr_custom_purchase_journal',
+            },
         }
 
     @template('cr_custom', 'account.journal')


### PR DESCRIPTION
## Summary
- wrap the Costa Rica chart template definition inside the required template_data key so it can be loaded by the account template loader

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5c9e704d0832681808629b5a514a5