### PR TITLE
Load sales purchase report template in data

### DIFF
--- a/l10n_cr_custom_19_v1/__manifest__.py
+++ b/l10n_cr_custom_19_v1/__manifest__.py
@@ -16,11 +16,10 @@
         "data/template/account.tax-cr.csv",
         "data/template/account.fiscal.position-cr.csv",
         "report/report_sales_purchase.xml",
+        "report/report_sales_purchase_templates.xml",
         "wizard/tax_report_wizard_views.xml",
     ],
-    "qweb": [
-        "report/report_sales_purchase_templates.xml"
-    ],
+    "qweb": [],
     "demo": [],
     "installable": True,
     "application": False,


### PR DESCRIPTION
## Summary
- load the sales/purchase report templates through the module data list so the QWeb report definition is available
- leave the qweb manifest entry empty since the templates are already covered by data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5d70dcaa88326a8b0a5f4194febe0