### PR TITLE
Rename tax report wizard model identifier

### DIFF
--- a/l10n_cr_custom_19_v1/wizard/tax_report_wizard.py
+++ b/l10n_cr_custom_19_v1/wizard/tax_report_wizard.py
@@ -2,7 +2,7 @@ from odoo import fields, models
 
 
 class TaxReportWizard(models.TransientModel):
-    _name = 'l10n.cr.tax.report.wizard'
+    _name = 'l10n.cr.custom.tax.report.wizard'
     _description = 'Asistente de Reporte de Compras y Ventas'
 
     date_from = fields.Date(string='Fecha desde')

--- a/l10n_cr_custom_19_v1/wizard/tax_report_wizard_views.xml
+++ b/l10n_cr_custom_19_v1/wizard/tax_report_wizard_views.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <record id="view_tax_report_wizard_form" model="ir.ui.view">
-        <field name="name">l10n.cr.tax.report.wizard.form</field>
-        <field name="model">l10n.cr.tax.report.wizard</field>
+        <field name="name">l10n.cr.custom.tax.report.wizard.form</field>
+        <field name="model">l10n.cr.custom.tax.report.wizard</field>
         <field name="arch" type="xml">
             <form string="Reporte de Compras y Ventas">
                 <group>
@@ -23,7 +23,7 @@
 
     <record id="action_tax_report_wizard" model="ir.actions.act_window">
         <field name="name">Reporte de Compras y Ventas</field>
-        <field name="res_model">l10n.cr.tax.report.wizard</field>
+        <field name="res_model">l10n.cr.custom.tax.report.wizard</field>
         <field name="view_mode">form</field>
         <field name="view_id" ref="view_tax_report_wizard_form"/>
         <field name="target">new</field>


### PR DESCRIPTION
## Summary
- rename the tax report wizard transient model to use a unique technical identifier
- update the wizard view and action definitions to reference the new model name

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d5d9e291148326ae97a08b4be2f244