### PR TITLE
Ensure Costa Rica chart template is selectable

### DIFF
--- a/l10n_cr_custom_19_v1/models/template_cr.py
+++ b/l10n_cr_custom_19_v1/models/template_cr.py
@@ -14,6 +14,7 @@ class L10nCRTemplate(models.AbstractModel):
                 'visible': True,
                 'code_digits': '7',
                 'country_id': 'base.cr',
+                'chart_template_ref': 'cr_custom',
 
             },
             'property_account_receivable_id': 'cr_coa_1040101',


### PR DESCRIPTION
## Summary
- set the chart template reference for the Costa Rica localization template so it can be discovered in the accounting packages list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5e8b983ac83268cc6520e7d73b782