### PR TITLE
Make chart template selectable without extra dependencies

### DIFF
--- a/l10n_cr_custom_19_v1/__manifest__.py
+++ b/l10n_cr_custom_19_v1/__manifest__.py
@@ -10,13 +10,9 @@
     "license": "LGPL-3",
     "depends": [
         "account",
-        "contacts",
-        "uom",
-        "account_reports",
-        "l10n_latam_base",
-        "l10n_latam_invoice_document",
     ],
     "data": [
+        "data/account_chart_template_data.xml",
         "data/account_tax_tags.xml",
         "report/report_sales_purchase.xml",
         "report/report_sales_purchase_templates.xml",

--- a/l10n_cr_custom_19_v1/data/account_chart_template_data.xml
+++ b/l10n_cr_custom_19_v1/data/account_chart_template_data.xml
@@ -1,0 +1,11 @@
+<odoo>
+    <data noupdate="1">
+        <record id="cr_custom" model="account.chart.template">
+            <field name="name">Costa Rica - Custom</field>
+            <field name="visible">True</field>
+            <field name="code_digits">7</field>
+            <field name="country_id" ref="base.cr"/>
+            <field name="chart_template_ref">l10n_cr_custom_19_v1.cr_custom</field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
## Summary
- expose the Costa Rican custom chart template through a dedicated XML record so it shows up in the chart installation wizard
- trim the module dependency list to `account` so it can be installed without missing optional addons

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5fed3f6e88326b75944d47f1af912