### PR TITLE
Add account_accountant dependency for chart template data

### DIFF
--- a/l10n_cr_custom_19_v1/__manifest__.py
+++ b/l10n_cr_custom_19_v1/__manifest__.py
@@ -10,6 +10,7 @@
     "license": "LGPL-3",
     "depends": [
         "account",
+        "account_accountant",
     ],
     "data": [
         "data/account_chart_template_data.xml",


### PR DESCRIPTION
## Summary
- ensure the Costa Rica localization installs the account_accountant module so the chart template model exists when loading data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d63f88a0508326a56408def257bd34