### PR TITLE
Ensure post-init hook is exposed

### DIFF
--- a/l10n_cr_custom_19_v1/__init__.py
+++ b/l10n_cr_custom_19_v1/__init__.py
@@ -1,3 +1,8 @@
 from . import models
 from . import reports
 from . import wizard
+from .hooks import post_init_hook
+
+__all__ = [
+    'post_init_hook',
+]


### PR DESCRIPTION
## Summary
- import the module's post-init hook in the package initializer so it is exposed
- export the hook via __all__ to make it discoverable by Odoo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64513372c8326b45d8fe528b5cf87