### PR TITLE
Make post-init hook accept env context

### DIFF
--- a/l10n_cr_custom_19_v1/__init__.py
+++ b/l10n_cr_custom_19_v1/__init__.py
@@ -1,3 +1,8 @@
 from . import models
 from . import reports
 from . import wizard
+from .hooks import post_init_hook
+
+__all__ = [
+    'post_init_hook',
+]

--- a/l10n_cr_custom_19_v1/hooks.py
+++ b/l10n_cr_custom_19_v1/hooks.py
@@ -35,6 +35,12 @@ def _ensure_chart_template(env):
         template.write({'chart_template_ref': template.id})
 
 
-def post_init_hook(cr, registry):
-    env = api.Environment(cr, SUPERUSER_ID, {})
+def post_init_hook(env_or_cr, registry=None):
+    """Ensure compatibility with both env and cr signatures."""
+
+    if isinstance(env_or_cr, api.Environment):
+        env = env_or_cr
+    else:
+        env = api.Environment(env_or_cr, SUPERUSER_ID, {})
+
     _ensure_chart_template(env)


### PR DESCRIPTION
## Summary
- update the post-init hook to support both legacy (cr, registry) and new (env) signatures
- keep the chart template initialization logic working regardless of how Odoo invokes the hook

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d64513372c8326b45d8fe528b5cf87