### PR TITLE
Fix formatLang availability in sales purchase report context

### DIFF
--- a/l10n_cr_custom_reports/reports/report_sales_purchase.py
+++ b/l10n_cr_custom_reports/reports/report_sales_purchase.py
@@ -3,6 +3,7 @@
 from collections import defaultdict
 
 from odoo import fields, models
+from odoo.tools import formatLang
 
 
 class ReportSalesPurchase(models.AbstractModel):
@@ -90,6 +91,11 @@ class ReportSalesPurchase(models.AbstractModel):
 
         show_details = bool(self.env.context.get('report_detail') or (data or {}).get('report_detail'))
 
+        def _format_lang(amount, **kwargs):
+            options = {'currency_obj': company_currency}
+            options.update(kwargs)
+            return formatLang(self.env, amount, **options)
+
         return {
             'doc_ids': relevant_moves.ids,
             'doc_model': 'account.move',
@@ -106,6 +112,7 @@ class ReportSalesPurchase(models.AbstractModel):
             'show_details': show_details,
             'company': company,
             'company_currency': company_currency,
+            'formatLang': _format_lang,
         }
 
 


### PR DESCRIPTION
## Summary
- expose Odoo's formatLang helper to the sales and purchase report templates
- default the helper to the company currency to avoid missing currency arguments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de535b67a48326abba6eef047a1ab1